### PR TITLE
MULE-9732 DefaultExtensionFactory is setting the incorrect ClassLoader

### DIFF
--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/introspection/ExtensionFactory.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/introspection/ExtensionFactory.java
@@ -23,14 +23,6 @@ public interface ExtensionFactory
 {
 
     /**
-     * Creates a {@link ExtensionModel} from the given {@code declarer}
-     *
-     * @param declarer an {@link ExtensionDeclarer}. Cannot be {@code null}
-     * @return an {@link RuntimeExtensionModel}
-     */
-    RuntimeExtensionModel createFrom(ExtensionDeclarer declarer);
-
-    /**
      * Creates a {@link RuntimeExtensionModel} from the given {@code declarer}
      * using a specifying {@code describingContext}
      *


### PR DESCRIPTION
_There is a PR in MULE that really has the fix for this issue, that one should have to be reviewed first before closing this PR
_This PR is in order to remove a method from the interface implemented in MULE that is no longer needed and used