### PR TITLE
MULE-10069: Artifact must export resource files instead of resource's…

### DIFF
--- a/mule-extensions-api-xml-dsl/src/main/resources/META-INF/mule-module.properties
+++ b/mule-extensions-api-xml-dsl/src/main/resources/META-INF/mule-module.properties
@@ -6,4 +6,4 @@ artifact.export.classPackages=org.mule.runtime.extension.xml.dsl,\
                               org.mule.runtime.extension.xml.dsl.api.resolver,\
                               org.mule.runtime.extension.api.annotation.dsl.xml
 
-artifact.export.resourcePackages=/META-INF
+artifact.export.resources=/META-INF


### PR DESCRIPTION
… folder paths

_ Renaming artifact descriptor property artifact.export.resourcePackages to artifact.export.resources