### PR TITLE
MULE-11084: Improve schema for validations

### DIFF
--- a/mule-extensions-api-xml-dsl/src/main/java/org/mule/runtime/extension/xml/dsl/api/DslElementSyntax.java
+++ b/mule-extensions-api-xml-dsl/src/main/java/org/mule/runtime/extension/xml/dsl/api/DslElementSyntax.java
@@ -26,6 +26,7 @@ public class DslElementSyntax {
   private final String elementNameSpace;
   private final String nameSpaceUri;
   private final boolean isWrapped;
+  private final boolean supportsAttributeDeclaration;
   private final boolean supportsChildDeclaration;
   private final boolean supportsTopLevelDeclaration;
   private final boolean requiresConfig;
@@ -36,33 +37,34 @@ public class DslElementSyntax {
   /**
    * Creates a new instance of {@link DslElementSyntax}
    *
-   * @param attributeName            the name of the attribute in the parent element that
-   *                                 references this element
-   * @param elementName              the name of this xml element
-   * @param elementNameSpace         the namespace of this xml element
-   * @param isWrapped                {@code false} if the element implements the Component's type
-   *                                 as an xml extension, or {@code true} if the element is a
-   *                                 wrapper of a ref to the Component's type
-   * @param supportsChildDeclaration {@code true} if this element supports to be declared as a
-   *                                 child element of its parent
-   * @param requiresConfig           whether the element requires a parameter pointing to the
-   *                                 config
-   * @param genericsDsl              the {@link DslElementSyntax} of this element's type generics,
-   *                                 if any is present, that complete the element description of
-   *                                 container elements of generic types, like Collections or Maps
-   *                                 for which the Dsl declaration is modified depending on the
-   *                                 contained type.
-   * @param childsByName             the {@link DslElementSyntax} of this element's named childs.
-   *                                 For complex types with fields that are mapped as child
-   *                                 elements of this element, the Dsl varies depending on each
-   *                                 fields definition, associating each field's child element to
-   *                                 this
+   * @param attributeName                the name of the attribute in the parent element that
+   *                                     references this element
+   * @param elementName                  the name of this xml element
+   * @param elementNameSpace             the namespace of this xml element
+   * @param isWrapped                    {@code false} if the element implements the Component's type
+   *                                     as an xml extension, or {@code true} if the element is a
+   *                                     wrapper of a ref to the Component's type
+   * @param supportsAttributeDeclaration {@code true} if this element supports to be declared as an
+   *                                     attribute in the parent element
+   * @param supportsChildDeclaration     {@code true} if this element supports to be declared as a
+   *                                     child element of its parent
+   * @param requiresConfig               whether the element requires a parameter pointing to the
+   *                                     config
+   * @param genericsDsl                  the {@link DslElementSyntax} of this element's type generics,
+   *                                     if any is present, that complete the element description of
+   *                                     container elements of generic types, like Collections or Maps
+   *                                     for which the Dsl declaration is modified depending on the
+   *                                     contained type.
+   * @param childsByName                 the {@link DslElementSyntax} of this element's named childs.
+   *                                     For complex types with fields that are mapped as child
+   *                                     elements of this element, the Dsl varies depending on each
+   *                                     fields definition, associating each field's child element to
    */
   public DslElementSyntax(String attributeName, String elementName,
                           String elementNameSpace,
                           String nameSpaceUri,
                           boolean isWrapped,
-                          boolean supportsChildDeclaration,
+                          boolean supportsAttributeDeclaration, boolean supportsChildDeclaration,
                           boolean supportsTopLevelDeclaration,
                           boolean requiresConfig,
                           Map<MetadataType, DslElementSyntax> genericsDsl,
@@ -72,6 +74,7 @@ public class DslElementSyntax {
     this.elementNameSpace = elementNameSpace;
     this.nameSpaceUri = nameSpaceUri;
     this.isWrapped = isWrapped;
+    this.supportsAttributeDeclaration = supportsAttributeDeclaration;
     this.supportsChildDeclaration = supportsChildDeclaration;
     this.supportsTopLevelDeclaration = supportsTopLevelDeclaration;
     this.requiresConfig = requiresConfig;
@@ -113,6 +116,13 @@ public class DslElementSyntax {
    */
   public String getAttributeName() {
     return attributeName;
+  }
+
+  /**
+   * @return {@code true} if this element supports to be declared as an attribute of its parent
+   */
+  public boolean supportsAttributeDeclaration() {
+    return supportsAttributeDeclaration;
   }
 
   /**

--- a/mule-extensions-api-xml-dsl/src/main/java/org/mule/runtime/extension/xml/dsl/internal/DslElementSyntaxBuilder.java
+++ b/mule-extensions-api-xml-dsl/src/main/java/org/mule/runtime/extension/xml/dsl/internal/DslElementSyntaxBuilder.java
@@ -29,6 +29,7 @@ public final class DslElementSyntaxBuilder {
   private String elementNameSpace = "";
   private String nameSpaceUri;
   private boolean isWrapped = false;
+  private boolean supportsAttributeDeclaration = true;
   private boolean supportsChildDeclaration = false;
   private boolean supportsTopLevelDeclaration = false;
   private boolean requiresConfig = false;
@@ -85,6 +86,17 @@ public final class DslElementSyntaxBuilder {
    */
   public DslElementSyntaxBuilder asWrappedElement(boolean isWrapped) {
     this.isWrapped = isWrapped;
+    return this;
+  }
+
+  /**
+   * Declares whether or not {@code this} {@link DslElementSyntax} supports to be declared as
+   * an attribute in the context for which it was created.
+   *
+   * @return {@code this} builder instance enriched with {@code supportsAttributeDeclaration}
+   */
+  public DslElementSyntaxBuilder supportsAttributeDeclaration(boolean supportsAttribute) {
+    this.supportsAttributeDeclaration = supportsAttribute;
     return this;
   }
 
@@ -156,7 +168,8 @@ public final class DslElementSyntaxBuilder {
    */
   public DslElementSyntax build() {
     return new DslElementSyntax(attributeName, elementName, elementNameSpace, nameSpaceUri, isWrapped,
-                                supportsChildDeclaration, supportsTopLevelDeclaration, requiresConfig, genericChilds,
+                                supportsAttributeDeclaration, supportsChildDeclaration, supportsTopLevelDeclaration,
+                                requiresConfig, genericChilds,
                                 namedChilds);
   }
 

--- a/mule-extensions-api-xml-dsl/src/test/java/org/mule/runtime/extension/xml/dsl/test/BaseXmlDeclarationTestCase.java
+++ b/mule-extensions-api-xml-dsl/src/test/java/org/mule/runtime/extension/xml/dsl/test/BaseXmlDeclarationTestCase.java
@@ -196,6 +196,10 @@ public abstract class BaseXmlDeclarationTestCase {
     assertThat("Expected no wrapping but element is wrapped", result.isWrapped(), is(expected));
   }
 
+  void assertAttributeDeclaration(boolean expected, DslElementSyntax result) {
+    assertThat(result.supportsAttributeDeclaration(), is(expected));
+  }
+
   void assertAttributeName(String expected, DslElementSyntax result) {
     assertThat(result.getAttributeName(), equalTo(expected));
   }


### PR DESCRIPTION
* Support for better schema generation
* Fix DslSyntax to provide a better dsl representation of imported types and wrapped elements
* Add concept of "Attribute Not Supported" for content, text and "neither reference nor Expressions for a complex type parameter"