### PR TITLE
MULE-11101: Minor changes in Extension API to automate the release

### DIFF
--- a/mule-extensions-api-dsql/pom.xml
+++ b/mule-extensions-api-dsql/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.mule.extensions</groupId>
             <artifactId>mule-extensions-api</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>

--- a/update_deps_versions.sh
+++ b/update_deps_versions.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+updatePropertiesVersion() {
+  VERSION_TO_PROPERTY="$1"
+  POM_PROPERTY_PATH="$2"
+
+  # PROPERTIES argument should be passed as a literal "arrayName[@]" without $ because here using the ! it is double expanded
+  # to obtiain the values and declare again the array.
+  PROPERTIES=("${!3}")
+
+  echo "Updating deps in pom: $POM_PROPERTY_PATH"
+
+  for PROPERTY_NAME in "${PROPERTIES[@]}"
+  do
+
+      perl -0777 -i -pe "s/(<properties>.*<$PROPERTY_NAME)(.*)(\/$PROPERTY_NAME>.*<\/properties>)/\${1}>$VERSION_TO_PROPERTY<\${3}/s" "$POM_PROPERTY_PATH"
+      echo "- Updating property $PROPERTY_NAME version to $VERSION_TO_PROPERTY"
+
+  done
+}
+
+VERSION_TO=$1
+
+# Properties with releaseVersion in the root pom.xml
+propertiesDeps=("muleApiVersion"
+                "metadataModelApiVersion")
+
+updatePropertiesVersion "$VERSION_TO" pom.xml propertiesDeps[@]
+
+
+


### PR DESCRIPTION
Added the update_deps_version.sh script.
Also changed "parent.version" for "project.version" for the mule-extensions-api dep in the dsql pom to work with the maven release plugin.