### PR TITLE
MULE-10366: Code formatter improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <javaFormatter.plugin.version>1.8.0</javaFormatter.plugin.version>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
+        <formatterGoal>validate</formatterGoal>
         <skipCodeFormatting>false</skipCodeFormatting>
     </properties>
 
@@ -218,7 +219,7 @@
                     <executions>
                         <execution>
                             <goals>
-                                <goal>validate</goal>
+                                <goal>${formatterGoal}</goal>
                             </goals>
                             <configuration>
                                 <skipFormatting>${skipCodeFormatting}</skipFormatting>


### PR DESCRIPTION
Extract formatter goal to a property to be able to use the 'format' goal in place of the 'validate' goal and format the code while compiling.