### PR TITLE
MULE-12987: Line ending formatter validation fails in windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <hamcrestVersion>1.3</hamcrestVersion>
         <xDocLint>-Xdoclint:none</xDocLint>
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
-        <javaFormatter.plugin.version>1.8.0</javaFormatter.plugin.version>
+        <javaFormatter.plugin.version>2.0.1</javaFormatter.plugin.version>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
         <formatterGoal>validate</formatterGoal>
         <skipCodeFormatting>false</skipCodeFormatting>
@@ -203,7 +203,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.marvinformatics.formatter</groupId>
+                    <groupId>net.revelc.code.formatter</groupId>
                     <artifactId>formatter-maven-plugin</artifactId>
                     <version>${javaFormatter.plugin.version}</version>
                     <configuration>
@@ -212,7 +212,6 @@
                         <compilerTargetPlatform>${javaVersion}</compilerTargetPlatform>
                         <configFile>${basedir}/${formatterConfigPath}</configFile>
                         <configJsFile>${basedir}/${formatterConfigPath}</configJsFile>
-                        <lineEnding>LF</lineEnding>
                         <aggregator>false</aggregator>
                         <executionRoot>true</executionRoot>
                     </configuration>
@@ -284,7 +283,7 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>com.marvinformatics.formatter</groupId>
+                <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
             </plugin>
             <plugin>


### PR DESCRIPTION
* Also update formatter plugin to 2.0.1