### PR TITLE
MULE-13172: WSC should not use MultiPartPayload anymore

### DIFF
--- a/mule-extensions-soap-api/src/main/java/org/mule/runtime/extension/api/soap/SoapAttributes.java
+++ b/mule-extensions-soap-api/src/main/java/org/mule/runtime/extension/api/soap/SoapAttributes.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.extension.api.soap;
+
+import static com.google.common.collect.ImmutableMap.copyOf;
+import static com.google.common.collect.ImmutableMap.of;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Contains the headers retrieved by the protocol after the request.
+ *
+ * @since 4.0
+ */
+public final class SoapAttributes implements Serializable {
+
+  private final Map<String, String> protocolHeaders;
+
+  public SoapAttributes(Map<String, String> protocolHeaders) {
+    this.protocolHeaders = protocolHeaders != null ? copyOf(protocolHeaders) : of();
+  }
+
+  /**
+   * @return a set of protocol headers bounded to the service response. i.e. HTTP Headers.
+   */
+  public Map<String, String> getProtocolHeaders() {
+    return protocolHeaders;
+  }
+}

--- a/mule-extensions-soap-api/src/main/java/org/mule/runtime/extension/api/soap/SoapOutputPayload.java
+++ b/mule-extensions-soap-api/src/main/java/org/mule/runtime/extension/api/soap/SoapOutputPayload.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.extension.api.soap;
+
+import org.mule.runtime.api.metadata.TypedValue;
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * A simple container object that carries the SOAP envelope information and the attachments bounded to the response.
+ *
+ * @since 4.0
+ */
+public class SoapOutputPayload {
+
+  private final TypedValue<InputStream> body;
+  private final Map<String, TypedValue<InputStream>> attachments;
+  private final Map<String, String> headers;
+
+  public SoapOutputPayload(TypedValue<InputStream> body,
+                           Map<String, TypedValue<InputStream>> attachments,
+                           Map<String, String> headers) {
+    this.body = body;
+    this.attachments = attachments;
+    this.headers = headers;
+  }
+
+  /**
+   * @return The xml response body. Represents the <SOAP:BODY> element
+   */
+  public TypedValue<InputStream> getBody() {
+    return body;
+  }
+
+  /**
+   * @return A set of attachments bounded to the response, an empty map if there is no attachments.
+   */
+  public Map<String, TypedValue<InputStream>> getAttachments() {
+    return attachments;
+  }
+
+  /**
+   * @return A set of XML SOAP headers. Represents the content inside the <SOAP:HEADERS> element.
+   */
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+}

--- a/mule-extensions-soap-api/src/main/java/org/mule/runtime/extension/internal/soap/metadata/SoapOutputTypeBuilder.java
+++ b/mule-extensions-soap-api/src/main/java/org/mule/runtime/extension/internal/soap/metadata/SoapOutputTypeBuilder.java
@@ -10,8 +10,6 @@ import org.mule.metadata.api.builder.BaseTypeBuilder;
 import org.mule.metadata.api.builder.ObjectTypeBuilder;
 import org.mule.metadata.api.model.MetadataType;
 import org.mule.metadata.api.model.NullType;
-import org.mule.metadata.api.visitor.MetadataTypeVisitor;
-import org.mule.runtime.api.util.Reference;
 
 /**
  * Helper class that builds the output types retrieved by Soap Connect extensions and WSC.
@@ -24,32 +22,27 @@ public class SoapOutputTypeBuilder {
   public final static String HEADERS_FIELD = "headers";
   public final static String ATTACHMENTS_FIELD = "attachments";
 
-  public static MetadataType buildOutputType(MetadataType body, MetadataType attachments, BaseTypeBuilder builder) {
-    Reference<MetadataType> result = new Reference<>();
-    attachments.accept(new MetadataTypeVisitor() {
+  public static MetadataType buildOutputType(MetadataType body, MetadataType headers,
+                                             MetadataType attachments, BaseTypeBuilder builder) {
 
-      @Override
-      protected void defaultVisit(MetadataType metadataType) {
-        ObjectTypeBuilder object = builder.objectType();
-        object.addField().key(BODY_FIELD).value(body);
-        object.addField().key(ATTACHMENTS_FIELD).value().arrayType().of(builder.anyType());
-        result.set(object.build());
-      }
+    if (isNullType(body) && isNullType(attachments) && isNullType(headers)) {
+      return builder.nullType().build();
+    }
 
-      @Override
-      public void visitNull(NullType nullType) {
-        result.set(body);
-      }
-    });
-    return result.get();
+    ObjectTypeBuilder object = builder.objectType();
+    if (!isNullType(body)) {
+      object.addField().key(BODY_FIELD).value(body);
+    }
+    if (!isNullType(headers)) {
+      object.addField().key(HEADERS_FIELD).value(headers);
+    }
+    if (!isNullType(attachments)) {
+      object.addField().key(ATTACHMENTS_FIELD).value().arrayType().of(builder.binaryType());
+    }
+    return object.build();
   }
 
-  public static MetadataType buildOutputAttributesType(MetadataType soapHeaders, BaseTypeBuilder builder) {
-    ObjectTypeBuilder attributes = builder.objectType();
-    attributes.addField().key(HEADERS_FIELD).value(soapHeaders);
-    ObjectTypeBuilder protocolHeaders = attributes.addField().key("protocolHeaders").value().objectType();
-    protocolHeaders.openWith().stringType();
-    return attributes.build();
+  private static boolean isNullType(MetadataType type) {
+    return type instanceof NullType;
   }
-
 }


### PR DESCRIPTION
## Removing Multipart Payload and Soap Connect Extensions

WSC and SC based extensions used to return a MultipartPayload with the content of the envelope body and attachments if any or just a simple XML if no attachments were involved, in favour of removing the MultipartPayload from all connectors now the consume operation  *ALWAYS* returns an object with the following structure:

- output  
|  - body 
|  - headers
|  - attachments

note that the payload now carries the soap headers, that previously were being bundled in the attributes (This is because we want that the whole SOAP ENVELOPE is represented in the payload)

## OUTPUT MIGRATION
### Soap Body
for accessing the body previously there were two ways:
* an operation with attachments `#[payload.body]`
* an operation without attachments `#[payload]`

Now *with or without* attachments is just `#[payload.body]`

### Soap Headers
Soap Headers used to live in the attributes, now they have been moved to the payload.
`[#attributes.headers]` -> `#[payload.headers]`

### Attachments
To access the attachments nothing has changed. i.e`#[payload.attachments.myAtt]` accesing an attachment called *myAtt*

