### PR TITLE
MULE-13851: Soapkit extension needs access to privileged Extension API

### DIFF
--- a/mule-extensions-api/src/main/resources/META-INF/mule-module.properties
+++ b/mule-extensions-api/src/main/resources/META-INF/mule-module.properties
@@ -59,5 +59,6 @@ artifact.privileged.artifactIds=com.mulesoft.munit:munit-runner,\
                                 com.mulesoft.munit:munit-tools,\
                                 org.mule.runtime:mule-module-extensions-support,\
                                 org.mule.modules:mule-scripting-module,\
-                                org.mule.modules:mule-validation-module
+                                org.mule.modules:mule-validation-module,\
+                                org.mule.modules:mule-soapkit-module
 


### PR DESCRIPTION
Since SOAPKit needs route flows we need include SOAPKit Extension to use privilege API.

SOAPKIt Spec can be reached here:
https://docs.google.com/document/d/10aO_5K-WecIwbbB7oGZYfqc63ne4wtLSKO--HVG8BGw/edit#