### PR TITLE
MULE-18675: Dynamic Configurations are expired even though a paginated operation is still using it

### DIFF
--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/runtime/config/ExpirableConfigurationProvider.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/runtime/config/ExpirableConfigurationProvider.java
@@ -17,11 +17,8 @@ import java.util.List;
  * when it tries to locate expired configurations which need disposal
  *
  * @since 1.0
- * @deprecated since 1.4.0, the expirable configuration providers must handle expirations internally by
- * calling {@link ExtensionManager#disposeConfiguration(String key, ConfigurationInstance configuration)}.
  */
 @NoImplement
-@Deprecated
 public interface ExpirableConfigurationProvider extends ConfigurationProvider {
 
   /**


### PR DESCRIPTION
As part of the fix for MULE-18675, the following revert is needed: Revert "MULE-18623: Deprecate interface ExpirableConfigurationProvider". This reverts commit 614b83d88e0343128f99516ece366d5bd1ae61b2.