### PR TITLE
DRAFT: Infrastructure Parameter Values [DO NOT MERGE]

### DIFF
--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/ArrayValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/ArrayValueDeclarer.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.extension.api.component.value;
 
+import org.mule.api.annotation.Experimental;
 import org.mule.api.annotation.NoImplement;
 
 import java.util.function.Consumer;
@@ -17,6 +18,7 @@ import java.util.function.Consumer;
  * 
  * @since 1.5.0
  */
+@Experimental
 @NoImplement
 public interface ArrayValueDeclarer {
 

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/ObjectValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/ObjectValueDeclarer.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.extension.api.component.value;
 
+import org.mule.api.annotation.Experimental;
 import org.mule.api.annotation.NoImplement;
 
 import java.util.function.Consumer;
@@ -17,6 +18,7 @@ import java.util.function.Consumer;
  *
  * @since 1.5.0
  */
+@Experimental
 @NoImplement
 public interface ObjectValueDeclarer {
 

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/PoolingProfileValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/PoolingProfileValueDeclarer.java
@@ -14,7 +14,7 @@ import org.mule.runtime.api.connection.ConnectionProvider;
 /**
  * Configures the {@link PoolingProfile} of a {@link ConnectionProvider} capable of pooling connections
  *
- * @since 1.0
+ * @since 1.5
  */
 @Experimental
 @NoImplement

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/PoolingProfileValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/PoolingProfileValueDeclarer.java
@@ -79,7 +79,7 @@ public interface PoolingProfileValueDeclarer {
   /**
    * List the policies on how can a pool be initialised
    *
-   * @since 1.0
+   * @since 1.5
    */
   @Experimental
   enum InitialisationPolicy {
@@ -102,7 +102,7 @@ public interface PoolingProfileValueDeclarer {
   /**
    * Policies on how to act when the pool is exhausted
    *
-   * @since 1.0
+   * @since 1.5
    */
   @Experimental
   enum ExhaustedAction {

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/PoolingProfileValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/PoolingProfileValueDeclarer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.extension.api.component.value;
+
+import org.mule.api.annotation.Experimental;
+import org.mule.api.annotation.NoImplement;
+import org.mule.runtime.api.config.PoolingProfile;
+import org.mule.runtime.api.connection.ConnectionProvider;
+
+/**
+ * Configures the {@link PoolingProfile} of a {@link ConnectionProvider} capable of pooling connections
+ *
+ * @since 1.0
+ */
+@Experimental
+@NoImplement
+public interface PoolingProfileValueDeclarer {
+
+  /**
+   * Sets the max number of active connections
+   *
+   * @param maxActive max number of connections
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer maxActive(int maxActive);
+
+  /**
+   * Sets the max number of idle connections
+   *
+   * @param maxIdle max number of idle connections
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer maxIdle(int maxIdle);
+
+  /**
+   * Sets the {@link InitialisationPolicy} on how the pool is initialised
+   *
+   * @param initialisationPolicy the initialisation policy
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer initialisationPolicy(InitialisationPolicy initialisationPolicy);
+
+  /**
+   * Sets the policy on how to act when the pool is exhausted
+   *
+   * @param exhaustedAction an {@link ExhaustedAction}
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer exhaustedAction(ExhaustedAction exhaustedAction);
+
+  /**
+   * Sets the max number of millis to wait when a connection is requested but none is available
+   *
+   * @param maxWait max wait time in millis
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer maxWait(long maxWait);
+
+  /**
+   * Sets the minimum time in millis after which an idle connection becomes eligible for eviction
+   *
+   * @param evictionMillis eviction time in millis
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer minEvictionMillis(int evictionMillis);
+
+  /**
+   * Sets how ofter does the pool checks for idle connections that can be evicted
+   *
+   * @param intervalMillis eviction interval in millis
+   * @return {@code this} instance
+   */
+  PoolingProfileValueDeclarer evictionCheckIntervalMillis(int intervalMillis);
+
+  /**
+   * List the policies on how can a pool be initialised
+   *
+   * @since 1.0
+   */
+  @Experimental
+  enum InitialisationPolicy {
+    /**
+     * Doesn't initialise any connection on startup. Connections are initialised on demand.
+     */
+    INITIALISE_NONE,
+
+    /**
+     * Initialises a single connection. Additional ones are initialised on demand.
+     */
+    INITIALISE_ONE,
+
+    /**
+     * Eagerly initialises all available connections
+     */
+    INITIALISE_ALL;
+  }
+
+  /**
+   * Policies on how to act when the pool is exhausted
+   *
+   * @since 1.0
+   */
+  @Experimental
+  enum ExhaustedAction {
+
+    /**
+     * If exhausted, augment the pool size
+     */
+    WHEN_EXHAUSTED_GROW,
+
+    /**
+     * If exhausted, wait for a new connection to become eligible
+     */
+    WHEN_EXHAUSTED_WAIT,
+
+    /**
+     * If exhausted, throw an Exception
+     */
+    WHEN_EXHAUSTED_FAIL
+  }
+}
+

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/ValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/component/value/ValueDeclarer.java
@@ -6,6 +6,7 @@
  */
 package org.mule.runtime.extension.api.component.value;
 
+import org.mule.api.annotation.Experimental;
 import org.mule.api.annotation.NoImplement;
 import org.mule.runtime.api.connection.ConnectionProvider;
 
@@ -16,6 +17,7 @@ import java.util.function.Consumer;
  *
  * @since 1.5.0
  */
+@Experimental
 @NoImplement
 public interface ValueDeclarer {
 
@@ -34,6 +36,14 @@ public interface ValueDeclarer {
    * @return the declarer to be used to declare the array value
    */
   void arrayValue(Consumer<ArrayValueDeclarer> arrayValueDeclarerConsumer);
+
+  /**
+   * Declares that the described value represents a {@link org.mule.runtime.api.config.PoolingProfile}
+   *
+   * @param poolingProfileValueDeclarerConsumer a consumer to configure the value of the pooling profile
+   * @return the declarer to be used to declare the pooling profile value
+   */
+  void poolingProfile(Consumer<PoolingProfileValueDeclarer> poolingProfileValueDeclarerConsumer);
 
   /**
    * Declares the value that is described by this declarer.

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/internal/component/value/DefaultPoolingProfileValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/internal/component/value/DefaultPoolingProfileValueDeclarer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.runtime.extension.internal.component.value;
+
+import static org.mule.runtime.api.config.PoolingProfile.DEFAULT_EVICTION_INTERVAL_MILLIS;
+import static org.mule.runtime.api.config.PoolingProfile.DEFAULT_MAX_POOL_ACTIVE;
+import static org.mule.runtime.api.config.PoolingProfile.DEFAULT_MAX_POOL_IDLE;
+import static org.mule.runtime.api.config.PoolingProfile.DEFAULT_MAX_POOL_WAIT;
+import static org.mule.runtime.api.config.PoolingProfile.DEFAULT_MIN_EVICTION_MILLIS;
+import static org.mule.runtime.extension.api.component.value.PoolingProfileValueDeclarer.ExhaustedAction.WHEN_EXHAUSTED_GROW;
+import static org.mule.runtime.extension.api.component.value.PoolingProfileValueDeclarer.InitialisationPolicy.INITIALISE_ONE;
+
+import org.mule.runtime.api.config.PoolingProfile;
+import org.mule.runtime.extension.api.component.value.PoolingProfileValueDeclarer;
+
+/**
+ * Default implementation of {@link PoolingProfileValueDeclarer}
+ *
+ * @since 1.5
+ */
+class DefaultPoolingProfileValueDeclarer implements PoolingProfileValueDeclarer, DefaultValueDeclarer.HasValue {
+
+  private int maxActive = DEFAULT_MAX_POOL_ACTIVE;
+  private int maxIdle = DEFAULT_MAX_POOL_IDLE;
+  private long maxWait = DEFAULT_MAX_POOL_WAIT;
+  private int minEvictionMillis = DEFAULT_MIN_EVICTION_MILLIS;
+  private int evictionCheckIntervalMillis = DEFAULT_EVICTION_INTERVAL_MILLIS;
+
+  private InitialisationPolicy initialisationPolicy = INITIALISE_ONE;
+  private ExhaustedAction exhaustedAction = WHEN_EXHAUSTED_GROW;
+
+  PoolingProfile toPoolingProfile() {
+    PoolingProfile pp = new PoolingProfile(maxActive, maxIdle, maxWait, exhaustedActionAsInt(), initialisationPolicyAsInt());
+    pp.setMinEvictionMillis(minEvictionMillis);
+    pp.setEvictionCheckIntervalMillis(evictionCheckIntervalMillis);
+
+    return pp;
+  }
+
+  private int exhaustedActionAsInt() {
+    switch (exhaustedAction) {
+      case WHEN_EXHAUSTED_GROW:
+        return PoolingProfile.WHEN_EXHAUSTED_GROW;
+      case WHEN_EXHAUSTED_FAIL:
+        return PoolingProfile.WHEN_EXHAUSTED_FAIL;
+      case WHEN_EXHAUSTED_WAIT:
+        return PoolingProfile.WHEN_EXHAUSTED_WAIT;
+      default:
+        throw new IllegalArgumentException("Unsupported ExhaustedAction: " + exhaustedAction);
+    }
+  }
+
+  private int initialisationPolicyAsInt() {
+    switch (initialisationPolicy) {
+      case INITIALISE_ONE:
+        return PoolingProfile.INITIALISE_ONE;
+      case INITIALISE_NONE:
+        return PoolingProfile.INITIALISE_NONE;
+      case INITIALISE_ALL:
+        return PoolingProfile.INITIALISE_ALL;
+      default:
+        throw new IllegalArgumentException("Unsupported InitialisationPolicy: " + initialisationPolicy);
+    }
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer maxActive(int maxActive) {
+    this.maxActive = maxActive;
+    return this;
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer maxIdle(int maxIdle) {
+    this.maxIdle = maxIdle;
+    return this;
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer initialisationPolicy(InitialisationPolicy initialisationPolicy) {
+    this.initialisationPolicy = initialisationPolicy;
+    return this;
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer exhaustedAction(ExhaustedAction exhaustedAction) {
+    this.exhaustedAction = exhaustedAction;
+    return this;
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer maxWait(long maxWait) {
+    this.maxWait = maxWait;
+    return this;
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer minEvictionMillis(int evictionMillis) {
+    this.minEvictionMillis = evictionMillis;
+    return this;
+  }
+
+  @Override
+  public PoolingProfileValueDeclarer evictionCheckIntervalMillis(int intervalMillis) {
+    evictionCheckIntervalMillis = intervalMillis;
+    return this;
+  }
+
+  @Override
+  public Object getValue() {
+    return toPoolingProfile();
+  }
+}

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/internal/component/value/DefaultValueDeclarer.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/internal/component/value/DefaultValueDeclarer.java
@@ -8,6 +8,7 @@ package org.mule.runtime.extension.internal.component.value;
 
 import org.mule.runtime.extension.api.component.value.ArrayValueDeclarer;
 import org.mule.runtime.extension.api.component.value.ObjectValueDeclarer;
+import org.mule.runtime.extension.api.component.value.PoolingProfileValueDeclarer;
 import org.mule.runtime.extension.api.component.value.ValueDeclarer;
 
 import java.util.ArrayList;
@@ -33,6 +34,12 @@ public class DefaultValueDeclarer implements ValueDeclarer {
   }
 
   @Override
+  public void poolingProfile(Consumer<PoolingProfileValueDeclarer> poolingProfileValueDeclarerConsumer) {
+    value = new DefaultPoolingProfileValueDeclarer();
+    poolingProfileValueDeclarerConsumer.accept((PoolingProfileValueDeclarer) value);
+  }
+
+  @Override
   public void withValue(Object value) {
     this.value = new SimpleHasValue(value);
   }
@@ -47,7 +54,7 @@ public class DefaultValueDeclarer implements ValueDeclarer {
     return valueDeclarer.getValue();
   }
 
-  private interface HasValue {
+  public static interface HasValue {
 
     Object getValue();
   }


### PR DESCRIPTION
This is a draft whose sole purpose is to show the handling for the declaration of value of infrastructure parameters. It only has the changes for supporting the PoolingProfile type in order to know if the solution is the expected one.

For this case, the new  PoolingProfileValueDeclarer in mule-extensions-api is a copy of the PoolingProfileConfigurer present in the mule-framework. The idea is to only have one, erasing the one in mule-framework and make the mule framework use this new one from mule-extensions-api.

The goal of this draft is to get early feedback on this particular case before implementing all the other cases. It add a way to declare the value of the infrastructure type PoolingProfile, a test that uses it, it makes the ConnectionProviderObjectBuilder take the pooling profile from the ResolverSet, and test is.

The changes are present in:
https://github.com/mulesoft/mule-extensions-api/pull/919
https://github.com/mulesoft/mule/pull/11727