### PR TITLE
W-12727109: Fix split package between mule-extensions-api and mule-extensions-api-persistence

### DIFF
--- a/mule-extensions-api-persistence/src/main/java/org/mule/runtime/extension/internal/xml/GenericXmlSerializer.java
+++ b/mule-extensions-api-persistence/src/main/java/org/mule/runtime/extension/internal/xml/GenericXmlSerializer.java
@@ -4,7 +4,7 @@
  * license, a copy of which has been included with this distribution in the
  * LICENSE.txt file.
  */
-package org.mule.runtime.extension.internal;
+package org.mule.runtime.extension.internal.xml;
 
 import org.mule.apache.xml.serialize.OutputFormat;
 import org.mule.apache.xml.serialize.XMLSerializer;
@@ -19,9 +19,8 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 /**
- * @deprecated Use org.mule.runtime.extension.internal.xml.GenericXmlSerializer instead, this will be removed in 1.6.0
+ * Moved from org.mule.runtime.extension.internal.GenericXmlSerializer<T>.
  */
-@Deprecated
 public class GenericXmlSerializer<T> {
 
   private JAXBContext jaxbContext;


### PR DESCRIPTION
* First part, copying since this is used by the extensions-maven-plugiun, we need this so that the plugin works with and withput the change as code changes between that repo and this are not atomic