### PR TITLE
W-13517980: Revapi validation must point to latest stable version, not a

### DIFF
--- a/mule-extensions-api/api-changes.json
+++ b/mule-extensions-api/api-changes.json
@@ -12,13 +12,7 @@
           "classSimpleName": "OperationParameterizer",
           "elementKind": "interface",
           "justification": "Metadata interface that doesn't affect behavior"
-        }
-      ]
-    }
-  },
-  "1.5.0": {
-    "revapi": {
-      "ignore": [
+        },
         {
           "code": "java.annotation.added",
           "old": "class org.mule.runtime.extension.api.loader.ExtensionModelLoader",

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <skipCodeFormatting>false</skipCodeFormatting>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <revapi-maven-plugin.version>0.9.5</revapi-maven-plugin.version>
-        <oldMuleArtifactVersion>1.5.0-SNAPSHOT</oldMuleArtifactVersion>
+        <oldMuleArtifactVersion>1.4.0</oldMuleArtifactVersion>
         <reactive-streams.version>1.0.2</reactive-streams.version>
 
         <muleRevapiExtensionVersion>1.6.0-SNAPSHOT</muleRevapiExtensionVersion>


### PR DESCRIPTION
snapshot