### PR TITLE
W-14616115: Enable default events tracking element is missing in all

### DIFF
--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/dsl/syntax/XmlDslSyntaxResolver.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/dsl/syntax/XmlDslSyntaxResolver.java
@@ -198,7 +198,8 @@ public class XmlDslSyntaxResolver implements DslSyntaxResolver {
     Reference<String> namespace = new Reference<>(languageModel.getNamespace());
     Reference<String> elementName = new Reference<>(hyphenize(parameter.getName()));
 
-    getCustomQName(parameter).ifPresent(qName -> {
+    final Optional<QName> customQName = getCustomQName(parameter);
+    customQName.ifPresent(qName -> {
       elementName.set(qName.getLocalPart());
       prefix.set(qName.getPrefix());
       namespace.set(qName.getNamespaceURI());
@@ -230,9 +231,7 @@ public class XmlDslSyntaxResolver implements DslSyntaxResolver {
                                    if (isContent) {
                                      addContentChildWithNoAttribute();
                                    } else {
-                                     builder.supportsAttributeDeclaration(true)
-                                         .supportsChildDeclaration(false)
-                                         .withAttributeName(parameter.getName());
+                                     addAttribute();
                                    }
                                  }
 
@@ -242,9 +241,19 @@ public class XmlDslSyntaxResolver implements DslSyntaxResolver {
                                    if (isText(parameter) || isContent) {
                                      addContentChildWithNoAttribute();
                                    } else {
-                                     builder.supportsAttributeDeclaration(true)
-                                         .supportsChildDeclaration(false)
-                                         .withAttributeName(parameter.getName());
+                                     addAttribute();
+                                   }
+                                 }
+
+                                 private void addAttribute() {
+                                   builder.supportsAttributeDeclaration(true)
+                                       .supportsChildDeclaration(false);
+
+                                   if (customQName.isPresent()) {
+                                     builder.withNamespace(prefix.get(), namespace.get());
+                                     builder.withAttributeName(elementName.get());
+                                   } else {
+                                     builder.withAttributeName(parameter.getName());
                                    }
                                  }
 

--- a/mule-extensions-api/src/test/java/org/mule/runtime/extension/api/test/dsl/BaseXmlDeclarationTestCase.java
+++ b/mule-extensions-api/src/test/java/org/mule/runtime/extension/api/test/dsl/BaseXmlDeclarationTestCase.java
@@ -66,12 +66,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.Rule;
 import org.junit.runners.Parameterized;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
 public abstract class BaseXmlDeclarationTestCase {
 
   static final String PREFIX = "mockns";
@@ -100,6 +101,9 @@ public abstract class BaseXmlDeclarationTestCase {
   public static Collection<ParameterRole> data() {
     return asList(ParameterRole.values());
   }
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule();
 
   @Mock(lenient = true)
   protected ExtensionModel extension;


### PR DESCRIPTION
core extension model elements that should support it

* Handle attributes with namespaces as parameters is so defined