### PR TITLE
W-17279758: Cache sanitized element names

### DIFF
--- a/mule-extensions-api/pom.xml
+++ b/mule-extensions-api/pom.xml
@@ -71,6 +71,14 @@
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
         
         <!-- JAXB and its dependencies... -->
         <dependency>

--- a/mule-extensions-api/src/main/java/module-info.java
+++ b/mule-extensions-api/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module org.mule.runtime.extensions.api {
 
   requires com.github.benmanes.caffeine;
   requires org.apache.commons.lang3;
+  requires org.apache.commons.text;
 
   // Required for the deprecated org.mule.runtime.extension.api.runtime.operation.ComponentExecutor<T>
   // that has its API defined in terms of org.reactivestreams.Publisher<Object>.

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/dsl/syntax/DslSyntaxUtils.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/dsl/syntax/DslSyntaxUtils.java
@@ -9,7 +9,7 @@ package org.mule.runtime.extension.api.dsl.syntax;
 import static java.util.Optional.ofNullable;
 import static java.util.regex.Pattern.compile;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.text.WordUtils.capitalize;
+import static org.apache.commons.text.WordUtils.capitalize;
 import static org.mule.runtime.api.meta.ExpressionSupport.NOT_SUPPORTED;
 import static org.mule.runtime.api.meta.ExpressionSupport.REQUIRED;
 import static org.mule.runtime.extension.api.util.ExtensionMetadataTypeUtils.allowsInlineDefinition;

--- a/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/dsl/syntax/XmlDslSyntaxResolver.java
+++ b/mule-extensions-api/src/main/java/org/mule/runtime/extension/api/dsl/syntax/XmlDslSyntaxResolver.java
@@ -110,6 +110,7 @@ public class XmlDslSyntaxResolver implements DslSyntaxResolver {
   private final ExtensionModel extensionModel;
   private final TypeCatalog typeCatalog;
   private final XmlDslModel languageModel;
+  private final Map<NamedObject, String> sanitizedElementNames = new HashMap<>();
   private final Map<String, DslElementSyntax> resolvedTypes = new HashMap<>();
   private final Map<MetadataType, XmlDslModel> importedTypes;
   private final Deque<String> typeResolvingStack = new ArrayDeque<>();
@@ -156,7 +157,7 @@ public class XmlDslSyntaxResolver implements DslSyntaxResolver {
    */
   @Override
   public DslElementSyntax resolve(final NamedObject component) {
-    final String elementName = getSanitizedElementName(component);
+    final String elementName = sanitizedElementNames.computeIfAbsent(component, DslSyntaxUtils::getSanitizedElementName);
     return computeIfAbsent(resolvedTypes, elementName, key -> {
       DslElementSyntaxBuilder dsl = DslElementSyntaxBuilder.create()
           .withElementName(elementName)


### PR DESCRIPTION
* Avoid the perf overhead of sanitizing the same name multiple times
* Replace deprecated WordUtils from commons-lang3 with the one from commons-text